### PR TITLE
Upgrade to kcl-lib 0.2.38 and bump version for 0.1.68 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "derive-docs"
-version = "0.1.34"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0511f0667f21fb0376ee645ca3df08124b772b19ee057deea254352f76063352"
+checksum = "4a06e8119b82bfd03dc6afe421026f064a858b8b3e74eb8767e1536bebb5a9db"
 dependencies = [
  "Inflector",
  "convert_case",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.1.67"
+version = "0.1.68"
 dependencies = [
  "anyhow",
  "clap",
@@ -1455,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.33"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f2fabce1dc5d6766d5ced1f6ce436b2dfe49936af1f3d074e009b688a993"
+checksum = "4c0972511a0732091b0f7c0b4647f78b29f9a4bf40cd2908877a74849b7448a9"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -1478,6 +1478,7 @@ dependencies = [
  "http",
  "image",
  "indexmap 2.7.1",
+ "itertools",
  "js-sys",
  "kittycad",
  "kittycad-modeling-cmds",
@@ -1716,9 +1717,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "cfg-if",
  "miette-derive",
@@ -1728,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2741,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.1.67"
+version = "0.1.68"
 edition = "2021"
 license = "MIT"
 
@@ -16,7 +16,7 @@ path = "src/main.rs"
 anyhow = "1.0.95"
 clap = { version = "4.5.30", features = ["cargo", "derive", "env", "unicode"] }
 dashmap = "6.1.0"
-kcl-lib = { version = "0.2.33", default-features = false, features = [
+kcl-lib = { version = "0.2.38", default-features = false, features = [
 	"cli",
 	"engine",
 	"disable-println",


### PR DESCRIPTION
Had to upgrade derive-docs manually.